### PR TITLE
fix(chatagent): SSE stream data race + Cursor Cloud dev env docs + skip CI for docs-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,20 @@ on:
       - 'cmd/composer/**'
       - 'docs/**'
       - 'tests/**'
+      - 'AGENTS.md'
+      - '**/AGENTS.md'
+      - 'README.md'
+      - '**/README.md'
   pull_request:
     paths-ignore:
       - 'cmd/cli/**'
       - 'cmd/composer/**'
       - 'docs/**'
       - 'tests/**'
+      - 'AGENTS.md'
+      - '**/AGENTS.md'
+      - 'README.md'
+      - '**/README.md'
 
 permissions:
   contents: read

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,9 +6,17 @@ on:
       - '*'
     paths-ignore:
       - 'docs/**'
+      - 'AGENTS.md'
+      - '**/AGENTS.md'
+      - 'README.md'
+      - '**/README.md'
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'AGENTS.md'
+      - '**/AGENTS.md'
+      - 'README.md'
+      - '**/README.md'
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Ent auto-migrates on server startup, so no manual migration step is needed.
 
 ### Config (`flowbot.yaml`, gitignored, already present at repo root)
 Non-obvious validation gotchas (see `pkg/config/validate.go`) when deriving config from `docs/reference/config.yaml`:
-- `redis.password` must be NON-empty (validator `required_if`), so Redis is run with `--requirepass flowbot`.
+- `redis.password` must be NON-empty (validator `required,min=1`), so Redis is run with `--requirepass flowbot`.
 - `platform.{slack,discord,tailchat,telegram}.enabled` are `true` in the reference file but their tokens are empty, which fails `required_if=Enabled true`; set them to `false` unless you supply real tokens.
 - `metrics.enabled` set to `false` (no VictoriaMetrics running); harmless to leave on but produces push errors.
 - `store_config` DSN points at `postgres://flowbot:flowbot@localhost/flowbot?sslmode=disable`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,29 @@ go tool task ent              # Generate ent code from database
 - Build: `taskfile.yaml`
 - Lint: `revive.toml`
 - CI: `.github/workflows/build.yml`
+
+## Cursor Cloud specific instructions
+
+Single Go product (server on port `:6060`) plus CLI helpers under `cmd/`. Requires PostgreSQL + Redis. The update script only runs `go mod download`; everything below must be done per session because it is not part of the update script.
+
+### Start services each session (systemd is unavailable)
+```bash
+sudo pg_ctlcluster 16 main start          # PostgreSQL 16 (data + role/db persist in snapshot)
+sudo redis-server --daemonize yes --save "" --requirepass flowbot   # password MUST match flowbot.yaml
+```
+DB role/database are `flowbot`/`flowbot` (password `flowbot`, superuser). Recreate only if missing:
+`sudo -u postgres psql -c "CREATE ROLE flowbot LOGIN PASSWORD 'flowbot' SUPERUSER;" -c "CREATE DATABASE flowbot OWNER flowbot;"`.
+Ent auto-migrates on server startup, so no manual migration step is needed.
+
+### Config (`flowbot.yaml`, gitignored, already present at repo root)
+Non-obvious validation gotchas (see `pkg/config/validate.go`) when deriving config from `docs/reference/config.yaml`:
+- `redis.password` must be NON-empty (validator `required_if`), so Redis is run with `--requirepass flowbot`.
+- `platform.{slack,discord,tailchat,telegram}.enabled` are `true` in the reference file but their tokens are empty, which fails `required_if=Enabled true`; set them to `false` unless you supply real tokens.
+- `metrics.enabled` set to `false` (no VictoriaMetrics running); harmless to leave on but produces push errors.
+- `store_config` DSN points at `postgres://flowbot:flowbot@localhost/flowbot?sslmode=disable`.
+
+### Run / build / lint / test
+- Run dev server: `go tool task run` (uses `go run -tags swagger ./cmd`). Health: `/livez`, `/readyz`. Web UI: `/service/web/login` (default creds `admin`/`admin` from `modules.web.auth`).
+- Lint (`go tool task lint`) includes a JS step (`oxlint ./public`); `oxlint` is installed globally via npm. If missing, run `npm install -g oxlint` (npm prefix must point inside the nvm node dir, e.g. `npm config set prefix "$HOME/.nvm/versions/node/v22.22.2"`, and that bin dir must be on PATH).
+- Unit tests (`go tool task test`) pass without Docker and use the running Redis.
+- `go tool task test:specs` (BDD) needs Docker/testcontainers, which is NOT installed here; install Docker first if you must run them.

--- a/internal/modules/web/agent_sessions_webservice.go
+++ b/internal/modules/web/agent_sessions_webservice.go
@@ -246,13 +246,17 @@ func agentSessionEvents(ctx fiber.Ctx) error {
 	ctx.Set("Cache-Control", "no-cache")
 	ctx.Set("Connection", "keep-alive")
 
+	// Resolve the request context before streaming. The SendStreamWriter
+	// callback runs in a separate goroutine after this handler returns, when
+	// Fiber has released and reused the fiber.Ctx; calling ctx.Context() from
+	// inside the callback races with that release.
+	reqCtx := ctx.Context()
 	return ctx.SendStreamWriter(func(w *bufio.Writer) {
 		hub := chatagent.GetSessionEventHub(sessionID)
 		subID := fmt.Sprintf("web-%p", w)
 		publisher := hub.Subscribe(subID, 32)
 		defer hub.Unsubscribe(subID)
 
-		reqCtx := ctx.Context()
 		for {
 			select {
 			case <-reqCtx.Done():

--- a/internal/server/chatagent_http_messages.go
+++ b/internal/server/chatagent_http_messages.go
@@ -40,6 +40,14 @@ func (h *chatAgentHTTP) sendMessage(c fiber.Ctx) error {
 	c.Set("Cache-Control", "no-cache")
 	c.Set("Connection", "keep-alive")
 
+	// Capture the base context before streaming. SendStreamWriter runs its
+	// callback in a separate goroutine after this handler returns, at which
+	// point Fiber releases and reuses the fiber.Ctx. Touching c (e.g.
+	// c.Context()) from inside the callback races with that release, so the
+	// parent context must be resolved here. The deferred cancel below still
+	// terminates the run when the stream ends (e.g. client disconnect).
+	baseCtx := c.Context()
+
 	return c.SendStreamWriter(func(w *bufio.Writer) {
 		hub := chatagent.GetSessionEventHub(sessionID)
 		subID := "run"
@@ -57,7 +65,7 @@ func (h *chatAgentHTTP) sendMessage(c fiber.Ctx) error {
 		}
 		defer chatagent.ClearAPIRunState(sessionID, runState)
 
-		runCtx, cancel := context.WithTimeout(c.Context(), chatagent.RunTimeout())
+		runCtx, cancel := context.WithTimeout(baseCtx, chatagent.RunTimeout())
 		defer cancel()
 		chatagent.BindRunCancel(sessionID, cancel)
 		defer chatagent.UnbindRunCancel(sessionID)

--- a/internal/server/chatagent_http_sessions.go
+++ b/internal/server/chatagent_http_sessions.go
@@ -187,16 +187,20 @@ func (h *chatAgentHTTP) sessionEvents(c fiber.Ctx) error {
 	c.Set("Cache-Control", "no-cache")
 	c.Set("Connection", "keep-alive")
 
+	// Resolve the request context before streaming. The SendStreamWriter
+	// callback runs in a separate goroutine after this handler returns, when
+	// Fiber has released and reused the fiber.Ctx; calling c.Context() from
+	// inside the callback races with that release.
+	reqCtx := c.Context()
 	return c.SendStreamWriter(func(w *bufio.Writer) {
 		hub := chatagent.GetSessionEventHub(sessionID)
 		subID := fmt.Sprintf("observer-%p", w)
 		publisher := hub.Subscribe(subID, 32)
 		defer hub.Unsubscribe(subID)
 
-		ctx := c.Context()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-reqCtx.Done():
 				return
 			case ev, ok := <-publisher.Events():
 				if !ok {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

1. **Fixes the flaky BDD CI failure** by removing a `fiber.Ctx` data race in the chat-agent SSE handlers. The `SendStreamWriter` callback runs in a separate goroutine after the handler returns, at which point Fiber v3 releases and reuses the `fiber.Ctx` (`release()` nils the stored context and `c.fasthttp`). Calling `c.Context()` from inside the callback races with that release and intermittently crashed a Ginkgo parallel process (exit status 2 → "a Ginkgo parallel process disappeared"), which `--flake-attempts` cannot recover. Fixed in three handlers by capturing the request context before streaming:
   - `internal/server/chatagent_http_messages.go` (`sendMessage`) — the one that caused the observed CI crash.
   - `internal/server/chatagent_http_sessions.go` (`sessionEvents`) — found during code review.
   - `internal/modules/web/agent_sessions_webservice.go` (`agentSessionEvents`) — found during code review.
   
   The other two `SendStreamWriter` callers (`watchPipelineRunLive`, `hubAppLogsSSE`) already captured the context correctly and were left unchanged.
2. Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting durable startup/run caveats for the dev environment.
3. Optimizes `.github/workflows/build.yml` and `.github/workflows/testing.yml` so changes limited to `AGENTS.md` / `README.md` (root and nested) no longer trigger the Build and Testing workflows.

### Root cause evidence
Reproduced locally with the race detector (`ginkgo --procs=4 --race --tags integration`):
```
WARNING: DATA RACE
Write at ... by goroutine 740: fasthttp.(*userData).Set  <- fiber releaseDefaultCtx (handler returned)
Previous read at ... by goroutine 741: DefaultCtx.Context  <- chatagent_http_messages.go:60 (stream writer)
```

### Verification
- `go tool task test:specs:ci` — ran 8x total across fixes, all pass, no crashes/races.
- `ginkgo --procs=4 --race ...` — no DATA RACE after the fixes.
- `go tool task lint` — passes.
- `go test ./internal/server/chatagent/...` — passes.
- Dev-env verification: `go tool task build`, `go tool task test` (7537 pass), `go tool task run` (`/livez`,`/readyz` = 200), web UI login + create token.

### Known unrelated flake (not fixed)
The spec `Chat Agent Chat API accepts cancel while a run is in flight` is a pre-existing timing flake that only surfaces under `-race`. It relies on the `cancelRun` handler publishing a `canceled` SSE event winning a race against the run goroutine's `publisher.Close()`. The real CI command runs without `-race` and with `--flake-attempts=2`, so it is not the cause of the red build. Left unchanged to avoid a product-behavior change; a robust fix would emit `canceled` in `sendMessage` whenever `runCtx` was canceled.

[Configs page after login](https://cursor.com/agents/bc-ec2c34a9-ae12-4e7e-96f2-70df6d5c86fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F00_after_login_configs.webp)
[Token created](https://cursor.com/agents/bc-ec2c34a9-ae12-4e7e-96f2-70df6d5c86fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F03_token_created.webp)
[Tokens list with hello-world token](https://cursor.com/agents/bc-ec2c34a9-ae12-4e7e-96f2-70df6d5c86fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F04_tokens_list.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec2c34a9-ae12-4e7e-96f2-70df6d5c86fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec2c34a9-ae12-4e7e-96f2-70df6d5c86fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clearer “Cursor Cloud specific instructions” for setting up PostgreSQL 16 and Redis per session.
  * Included session-specific configuration and validation guidance (including Redis password requirements and token enablement rules).
  * Clarified local run/build/lint/test steps, health endpoints (`/livez`, `/readyz`), default web login (`admin`/`admin`), and prerequisites for running BDD tests (Docker requirement).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->