### PR TITLE
fix(specs): repair BDD tests broken by stricter permission defaults

### DIFF
--- a/tests/specs/agent_sessions_page_spec_test.go
+++ b/tests/specs/agent_sessions_page_spec_test.go
@@ -97,6 +97,10 @@ func (a *agentSessionsWebAdapter) ListChatSessionEntries(ctx context.Context, se
 		All(ctx)
 }
 
+func (a *agentSessionsWebAdapter) ListAgentPlansBySession(_ context.Context, _ string) ([]*gen.AgentPlan, error) {
+	return nil, nil
+}
+
 func (a *agentSessionsWebAdapter) GetChatSessionEntryInSession(ctx context.Context, sessionID, flag string) (*gen.ChatSessionEntry, error) {
 	row, err := a.ent.ChatSessionEntry.Query().
 		Where(

--- a/tests/specs/chat_agent_spec_test.go
+++ b/tests/specs/chat_agent_spec_test.go
@@ -187,9 +187,34 @@ var _ = Describe("Chat Agent", Label("module", "chat-agent"), func() {
 
 		chatagent.WaitForSessionTitleGenerationForTest()
 		Expect(chatagent.SetSessionMode(ctx, sessionID, chatagent.ModeNormal)).To(Succeed())
-		reply, err = svc.Run(ctx, chatagent.RunRequest{SessionID: sessionID, Text: "now edit plan-mode-target.txt"}, nil)
+
+		// write_file requires approval by default; register a confirm gate and
+		// approve the pending request so the run can proceed, mirroring how an
+		// interactive client (cmd/chat or the HTTP SSE endpoint) resolves asks.
+		pub := chatagent.NewChannelPublisher(4)
+		gate := chatagent.NewConfirmGate(sessionID, pub)
+		runState := chatagent.NewAPIRunState(pub, gate)
+		Expect(chatagent.TrySetAPIRunState(sessionID, runState)).To(Succeed())
+		defer chatagent.ClearAPIRunState(sessionID, runState)
+
+		type runResult struct {
+			reply string
+			err   error
+		}
+		done := make(chan runResult, 1)
+		go func() {
+			r, runErr := svc.Run(ctx, chatagent.RunRequest{SessionID: sessionID, Text: "now edit plan-mode-target.txt"}, nil)
+			done <- runResult{reply: r, err: runErr}
+		}()
+
+		Eventually(pub.Events(), "5s").Should(Receive(HaveField("Type", chatagent.EventTypeConfirm)))
+		_, err = chatagent.ResolveConfirm(sessionID, gate.ID(), true, chatagent.ConfirmModeOnce, "", chatagent.ConfirmReasonApproved)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(reply).To(ContainSubstring("updated"))
+
+		var result runResult
+		Eventually(done, "5s").Should(Receive(&result))
+		Expect(result.err).NotTo(HaveOccurred())
+		Expect(result.reply).To(ContainSubstring("updated"))
 
 		_, statErr = os.Stat(filepath.Join(wsDir, target))
 		Expect(statErr).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the `bdd` CI job failure from https://github.com/flowline-io/flowbot/actions/runs/28654255777.

### Root causes

1. `Agent Sessions UI ... renders session detail with entries` — `agentSessionDetailPage` calls `chatagent.ListPlanSummaries`, which calls `store.Database.ListAgentPlansBySession` (added in `a883a518`). The BDD test's `agentSessionsWebAdapter` never implemented this method, so the call fell through to the embedded nil `store.Adapter` interface and panicked (`invalid memory address or nil pointer dereference`). The test harness's error handler maps any non-fiber/non-oops error to `400`, masking the panic as a plain status mismatch.
2. `Chat Agent ... blocks write_file in plan mode and allows it after returning to normal` — commit `cb76144a` changed `permission.DefaultConfig()`'s wildcard default from `Allow` to `Ask` and changed `handlePermissionAsk` to block (instead of allow) when no `ConfirmGate` is registered for the session. `write_file` already required `Ask` under the `edit` category, so once a run has no confirm gate, that write is now blocked (previously it was auto-allowed). The BDD spec called `svc.Run` directly with no `ConfirmGate`, so after this security hardening the second `write_file` call was silently blocked and the target file was never created.

### Fix

* Added `ListAgentPlansBySession` to the test's in-memory adapter.
* Updated the plan-mode spec to register a `ConfirmGate`/`APIRunState` for the session and approve the pending confirmation before asserting the write succeeded, mirroring how real interactive clients (`cmd/chat`, HTTP SSE) resolve `Ask` permissions.

No production code changes — these are BDD test fixes.

**Testing**
- `go tool task test:specs:ci` — 394 passed, 0 failed, 10 skipped (matches CI's split before the fix, now green).
- `go tool task test` — 7588 tests, 9 skipped, 0 failed.
- `go tool task lint` — clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f623551-2fb5-4c50-8217-a69887c5670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f623551-2fb5-4c50-8217-a69887c5670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for agent session handling to support additional session-related responses.
  * Improved chat workflow testing to verify confirmation handling before file edits are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->